### PR TITLE
Typescript is making main.js build size to be more than 12 MB in prod.

### DIFF
--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -3,7 +3,6 @@ module.exports = {
     entry: {
         main: path.resolve(__dirname, "..", "typescript", "main.ts"),
     },
-    devtool: 'inline-source-map',
     output: {
         library: "[name]",
         path: path.join(__dirname, "../lib/assets"),


### PR DESCRIPTION
My Webpack setup was bad. This is fixed, and now bundle size is around 3MB again.

Fixes #24