### PR TITLE
Stringbyte

### DIFF
--- a/lib/src/models/bytes.dart
+++ b/lib/src/models/bytes.dart
@@ -1,0 +1,24 @@
+extension StringByte on String {
+  String get strip0x {
+    if (startsWith('0x')) {
+      return substring(2);
+    }
+    return this;
+  }
+
+  String get toBytes {
+    final without0x = strip0x;
+    assert(_isHex(without0x));
+    return '0x$without0x';
+  }
+
+  /// Determines if a string is an hexadecimal
+  /// @param {String} inputString Potential hexadecimal string
+  bool _isHex(String inputString) {
+    final hexadecimal = RegExp(r'^([0-9A-Fa-f])*$');
+    if (!hexadecimal.hasMatch(inputString)) {
+      return false;
+    }
+    return true;
+  }
+}

--- a/lib/wagmi_flutter_web.dart
+++ b/lib/wagmi_flutter_web.dart
@@ -33,6 +33,7 @@ export 'src/actions/write_contract.dart';
 export 'src/models/abi.dart';
 export 'src/models/account.dart';
 export 'src/models/block_tag.dart';
+export 'src/models/bytes.dart';
 export 'src/models/chain.dart';
 export 'src/models/chain_block_explorer.dart';
 export 'src/models/chain_contract.dart';


### PR DESCRIPTION
Add `toBytes` method to ensure string bytes array use format required by wagmi.